### PR TITLE
feat: html2canvas 사용, 작업한 이미지 다운로드 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3613,6 +3613,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -4166,6 +4171,14 @@
       "integrity": "sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==",
       "requires": {
         "postcss-selector-parser": "^6.0.9"
+      }
+    },
+    "css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "requires": {
+        "utrie": "^1.0.2"
       }
     },
     "css-loader": {
@@ -6171,6 +6184,15 @@
         "lodash": "^4.17.21",
         "pretty-error": "^4.0.0",
         "tapable": "^2.0.0"
+      }
+    },
+    "html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "requires": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
       }
     },
     "htmlparser2": {
@@ -11146,6 +11168,14 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "requires": {
+        "utrie": "^1.0.2"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -11398,6 +11428,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "requires": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "html2canvas": "^1.4.1",
     "react": "^18.2.0",
     "react-color": "^2.19.3",
     "react-dom": "^18.2.0",

--- a/src/components/DownloadImage.js
+++ b/src/components/DownloadImage.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { FaDownload } from 'react-icons/fa';
+
+import useStore from '../store/store';
+import exportAsImage from '../utils/exportAsImage';
+
+import Button from './common/Button';
+const DownloadImage = () => {
+  const { gridRef } = useStore();
+  return (
+    <Button onClick={() => exportAsImage(gridRef.current, 'pixelImage')}>
+      <FaDownload />
+    </Button>
+  );
+};
+
+export default DownloadImage;

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import useStore from '../store/store';
 
 import Row from './Row';
 
 const Grid = ({ update }) => {
+  const gridRef = useRef(null);
+
+  useEffect(() => {
+    useStore.setState({ gridRef: gridRef });
+  }, []);
+
   const { canvas } = useStore();
   const grid = canvas?.map((color, index) => {
     return <Row key={index} cells={color} index={index} update={update} />;
   });
 
-  return <div>{grid}</div>;
+  return <div ref={gridRef}>{grid}</div>;
 };
 
 export default Grid;

--- a/src/components/LeftSidebar.js
+++ b/src/components/LeftSidebar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Bucket from './Bucket';
+import DownloadImage from './DownloadImage';
 import Eraser from './Eraser';
 import Eyedropper from './Eyedropper';
 import Paint from './Paint';
@@ -14,6 +15,9 @@ const LeftSidebar = () => {
         <Eraser />
         <Bucket />
         <Eyedropper />
+      </div>
+      <div>
+        <DownloadImage />
       </div>
       <div>
         <Pallette />

--- a/src/components/PixelCanvas.js
+++ b/src/components/PixelCanvas.js
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import styled from 'styled-components';
 
 import useStore from '../store/store';
 
 import Grid from './Grid';
+
 // 최적화 필요.
 const makeArray = (column, row, color) => {
   let canvas = Array(column);

--- a/src/utils/exportAsImage.js
+++ b/src/utils/exportAsImage.js
@@ -1,0 +1,40 @@
+import html2canvas from 'html2canvas';
+
+const exportAsImage = async (element, imageFileName) => {
+  const html = document.getElementsByTagName('html')[0];
+  const body = document.getElementsByTagName('body')[0];
+  let htmlWidth = html.clientWidth;
+  let bodyWidth = body.clientWidth;
+
+  const newWidth = element.scrollWidth - element.clientWidth;
+
+  if (newWidth > element.clientWidth) {
+    htmlWidth += newWidth;
+    bodyWidth += newWidth;
+  }
+  html.style.width = htmlWidth + 'px';
+  body.style.width = bodyWidth + 'px';
+
+  const canvas = await html2canvas(element);
+  const image = canvas.toDataURL('image/png', 1.0);
+
+  downloadImage(image, imageFileName);
+  html.style.width = null;
+  body.style.width = null;
+};
+
+const downloadImage = (blob, fileName) => {
+  const fakeLink = window.document.createElement('a');
+  fakeLink.style = 'display:none;';
+  fakeLink.download = fileName;
+
+  fakeLink.href = blob;
+
+  document.body.appendChild(fakeLink);
+  fakeLink.click();
+  document.body.removeChild(fakeLink);
+
+  fakeLink.remove();
+};
+
+export default exportAsImage;


### PR DESCRIPTION
## 개요

- html2canvas 라이브러리를 사용하여 현재 캔버스 페이지의 이미지를 png파일로 다운로드

## 작업사항

- LeftSidebar에 다운로드 버튼 생성 
-  'html2canvs' 라이브러리 설치
- grid component의 ref를 전역 스토어에서 관리하게끔 코드 작성

## 기타 이슈

- 없음.
