### PR TITLE
feat: 작업한 이미지 실시간으로 보여주기(Preview)

### DIFF
--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import useStore from '../store/store';
+
+const Preview = () => {
+  const { canvas, row, column } = useStore();
+
+  const PreviewRow = ({ cells }) => {
+    const rows = cells.map((color, i) => {
+      return (
+        <div
+          key={i}
+          style={{ backgroundColor: color, height: '5px', width: '5px' }}
+        />
+      );
+    });
+
+    return <Row>{rows}</Row>;
+  };
+  const previewGrid = canvas.map((color, index) => {
+    return <PreviewRow key={index} cells={color} />;
+  });
+
+  return (
+    <Container row={row} column={column}>
+      {previewGrid}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: ${(props) => props.row * 5}px;
+  height: ${(props) => props.column * 5}px;
+`;
+const Row = styled.div`
+  display: flex;
+`;
+
+export default Preview;

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -1,13 +1,26 @@
 import React from 'react';
 
+import styled from 'styled-components';
+
 import PanelDimensions from './PanelDimensions';
+import Preview from './Preview';
 
 const RightSidebar = () => {
   return (
     <>
+      <PreviewContainer>
+        <Preview />
+      </PreviewContainer>
+
       <PanelDimensions />
     </>
   );
 };
+
+const PreviewContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 20px;
+`;
 
 export default RightSidebar;

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -46,10 +46,12 @@ const Row = ({ cells, index, update }) => {
       if (selectedTools === 'BRUSH') {
         e.target.style.backgroundColor = selectedColor;
         update(i, index);
+        checkChangedColor();
       }
       if (selectedTools === 'ERASER') {
         e.target.style.backgroundColor = '#fff';
         update(i, index);
+        checkChangedColor();
       }
 
       return;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -2,8 +2,8 @@ import create from 'zustand';
 import { devtools } from 'zustand/middleware';
 
 const store = (set, get) => ({
-  row: 30,
-  column: 30,
+  row: 20,
+  column: 20,
   canvas: [],
   selectedColor: '#000',
   baseColor: '#fff',
@@ -13,6 +13,7 @@ const store = (set, get) => ({
   eyedropper: 'EYEDROPPER',
   selectedTools: 'BRUSH',
   hasChangedColor: false,
+  gridRef: {},
   floodFill: (image, sr, sc, newColor) => {
     const currColor = image[sr][sc];
     if (currColor === newColor) return image;

--- a/src/styles/EditorMain.styled.js
+++ b/src/styles/EditorMain.styled.js
@@ -15,6 +15,7 @@ export const CentralContainer = styled.div`
 export const LeftCol = styled.div`
   flex: 1;
   border: 1px solid red;
+  background-color: #303f46;
 `;
 
 export const CenterCol = styled.div`
@@ -24,5 +25,6 @@ export const CenterCol = styled.div`
 
 export const RightCol = styled.div`
   flex: 1;
+  background-color: #303f46;
   border: 1px solid red;
 `;


### PR DESCRIPTION
## 개요

- 현재 작업하고 있는 이미지가 실시간으로 작게 보인다

## 작업사항

- Preview.js 컴포넌트 생성

## 기타 이슈

- 해당 그리드를 다시 클론 렌더링 해야하나, 캡처한 사진을 계속 바꿔줘야하나 고민을 엄청했는데....생각을 잘해보니 전역 스토어에 저장되어있는 데이터를 가지고 미니 캔버스 만들어서 그냥 쏴주면 되는 거였음....... ㅠ
